### PR TITLE
Add config option for mpv fullscreen

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ struct AppConfig {
     channel_urls: Vec<String>,
     mpv_mode: bool,
     mpv_path: String,
+    fs: bool,
 }
 
 impl Default for AppConfig {
@@ -104,6 +105,7 @@ impl Default for AppConfig {
             channel_urls: vec![],
             mpv_mode: true,
             mpv_path: "/usr/bin/mpv".to_string(),
+            fs: true,
         }
     }
 }
@@ -811,7 +813,7 @@ fn play_url(url: &String, kind: &ItemKind, app_config: &AppConfig) {
         let message = format!("playing {} with mpv...", url);
         debug(&message);
             match Command::new(&app_config.mpv_path)
-            .arg("-fs")
+            .arg(if app_config.fs { "-fs" } else { "" })
             .arg("-really-quiet")
             .arg("--ytdl-format")
             .arg(&app_config.youtubedl_format)

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,17 +55,8 @@ impl From<reqwest::Error> for CustomError {
     }
 }
 
-
-fn default_mpv_mode() -> bool {
-    true
-}
-
 fn default_content() -> Option<String> {
     None
-}
-
-fn default_channel_urls() -> Vec<String> {
-    vec![]
 }
 
 fn default_kind_symbols() -> HashMap<String, String> {
@@ -77,26 +68,19 @@ fn default_kind_symbols() -> HashMap<String, String> {
     symbols
 }
 
-fn default_mpv_path() -> String {
-    "/usr/bin/mpv".to_string()
-}
-
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(default)]
 struct AppConfig {
     video_path: String,
     cache_path: String,
     youtubedl_format: String,
     video_extension: String,
-    #[serde(default = "default_kind_symbols")]
     kind_symbols: HashMap<String, String>,
     blockish_player: Option<String>,
     players: Vec<Vec<String>>,
     channel_ids: Vec<String>,
-    #[serde(default = "default_channel_urls")]
     channel_urls: Vec<String>,
-    #[serde(default = "default_mpv_mode")]
     mpv_mode: bool,
-    #[serde(default = "default_mpv_path")]
     mpv_path: String,
 }
 
@@ -117,9 +101,9 @@ impl Default for AppConfig {
                 vec!["/usr/bin/mplayer".to_string(), "-really-quiet".to_string(), "-fs".to_string()],
             ],
             channel_ids: vec![],
-            channel_urls: default_channel_urls(),
-            mpv_mode: default_mpv_mode(),
-            mpv_path: default_mpv_path(),
+            channel_urls: vec![],
+            mpv_mode: true,
+            mpv_path: "/usr/bin/mpv".to_string(),
         }
     }
 }


### PR DESCRIPTION
I wanted to be able to control whether `mpv` played in fullscreen or not. This PR adds a new config field: `fs` which is then checked in the `play_url` fn when building the args for `mpv`. 

I also made every field in `AppConfig` refer to the `impl Default` (via the `#[serde(default)]` annotation) for any values not found in `~/.config/youtube-subscriptions/config.json`. This allows a user to only change the specific config fields they want to customize. For example this config is now valid:
```
{
  "youtubedl_format": "bestvideo[ext = mp4]",
  "fs": false
}
```