### PR TITLE
update option syntax for ytdl-format for mpv.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -828,7 +828,7 @@ fn play_url(url: &String, kind: &ItemKind, app_config: &AppConfig) {
             match Command::new(&app_config.mpv_path)
             .arg(if app_config.fs { "-fs" } else { "" })
             .arg("-really-quiet")
-            .arg("--ytdl-format")
+            .arg("--ytdl-format=")
             .arg(&app_config.youtubedl_format)
             .arg(&url).spawn() {
                 Ok(mut child) => {


### PR DESCRIPTION
In v0.32.0 of mpv the way option parsing works changed[1]:

> options: change option parsing when using a single dash
> This adds a warning for -o file.mkv and disallows the use of
> --o file.mkv (use --o=file.mkv instead).

Using the old format `--ytdl-format "format string(s)"` results in this
error:

> Error parsing commandline option ytdl-format: option requires parameter

The solution is to add an `=` to explicitly tie the option name
to its value.

[1]: https://github.com/mpv-player/mpv/releases/tag/v0.32.0