### PR TITLE
Better first run experience

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ percent-encoding = { version = "2.1" }
 blockish = { version = "0.0.2" }
 blockish-player = { version = "0.0.3" }
 utf-8 =  { version = "0.7.5" }
+openssl-sys = { version = "*", features = ["vendored"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 blockish-caca = { version = "0.0.2" }


### PR DESCRIPTION
This addresses the issues in #75 and #77.

This work attempts to:
- creates a config file if there isn't one
- creates a cache directory if there isn't one
- If there's no config it should open the help menu on first run
- follow a few clippy suggestions 